### PR TITLE
feat(api): Part C — repro score, paper align, GitHub insight

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,11 @@ from fastapi.responses import StreamingResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 import uvicorn
 
+import logging
+
 from app.core.config import settings, auto_eval_config as runtime_auto_eval_config
+
+logger = logging.getLogger(__name__)
 from app.services.agent_service import agent_stream
 from app.services.chat_service import process_chat_stream, get_eval_data, clear_eval_data
 from app.services.insights_service import issue_summary_stream, commit_roadmap_stream
@@ -189,6 +193,108 @@ async def check_repo_session(request: Request):
             "has_index": False,
             "available_languages": [],
         })
+
+
+# === 可复现评分 & 论文-代码对齐 (Owner: C, 路由编排: A) ===
+
+def _unified_success(data: dict) -> JSONResponse:
+    return JSONResponse({"status": "success", "data": data, "error": None})
+
+
+def _unified_error(code: str, message: str, status_code: int = 400) -> JSONResponse:
+    return JSONResponse(
+        {"status": "error", "data": None, "error": {"code": code, "message": message, "details": {}}},
+        status_code=status_code,
+    )
+
+
+def _parse_insight_query_params(data: dict) -> tuple[int, int]:
+    """与 §3.1 一致：since_days、limit 可选，非法则回退默认。"""
+    since_days = data.get("since_days", 90)
+    limit = data.get("limit", 100)
+    if not isinstance(since_days, int) or not (1 <= since_days <= 365):
+        since_days = 90
+    if not isinstance(limit, int) or not (1 <= limit <= 500):
+        limit = 100
+    return since_days, limit
+
+
+@app.post("/api/repo/insight/issues-commits")
+async def repo_insight_issues_commits(request: Request):
+    """§3.1 Issues + Commits 洞察（成员 B 数据形态；实现供 C 评分融合与前端展示）"""
+    from app.services.issue_commit_insight_service import fetch_issue_commit_insight
+
+    data = await request.json()
+    repo_url = (data.get("repo_url") or data.get("url") or "").strip()
+    if not repo_url:
+        return _unified_error("INVALID_ARGUMENT", "repo_url is required")
+
+    since_days, limit = _parse_insight_query_params(data)
+
+    payload = await fetch_issue_commit_insight(repo_url, since_days=since_days, limit=limit)
+    return _unified_success(payload)
+
+
+@app.post("/api/repro/score")
+async def repro_score(request: Request):
+    """§3.2 可复现性评分"""
+    from app.services.repro_score_service import compute_repro_score
+
+    data = await request.json()
+    session_id = data.get("session_id")
+    repo_url = data.get("repo_url") or data.get("url")
+
+    if not session_id and not repo_url:
+        return _unified_error("INVALID_ARGUMENT", "session_id or repo_url is required")
+
+    since_days, limit = _parse_insight_query_params(data)
+
+    try:
+        result = await compute_repro_score(
+            session_id=session_id,
+            repo_url=repo_url,
+            insight_since_days=since_days,
+            insight_limit=limit,
+        )
+        return _unified_success(result.to_dict())
+    except ValueError as e:
+        return _unified_error("INVALID_ARGUMENT", str(e))
+    except Exception as e:
+        logger.exception("repro_score failed")
+        return _unified_error("INTERNAL", str(e), status_code=500)
+
+
+@app.post("/api/paper/align")
+async def paper_align(request: Request):
+    """§3.3 论文-代码对齐"""
+    from app.services.paper_align_service import compute_paper_alignment
+
+    data = await request.json()
+    paper_text = data.get("paper_text", "")
+    session_id = data.get("session_id")
+    repo_url = data.get("repo_url") or data.get("url")
+    top_k = data.get("top_k", 5)
+
+    if not paper_text or not paper_text.strip():
+        return _unified_error("INVALID_ARGUMENT", "paper_text is required")
+    if not session_id and not repo_url:
+        return _unified_error("INVALID_ARGUMENT", "session_id or repo_url is required")
+    if not isinstance(top_k, int) or not (1 <= top_k <= 20):
+        top_k = 5
+
+    try:
+        result = await compute_paper_alignment(
+            paper_text=paper_text,
+            session_id=session_id,
+            repo_url=repo_url,
+            top_k=top_k,
+        )
+        return _unified_success(result.to_dict())
+    except ValueError as e:
+        return _unified_error("INVALID_ARGUMENT", str(e))
+    except Exception as e:
+        logger.exception("paper_align failed")
+        return _unified_error("INTERNAL", str(e), status_code=500)
 
 
 @app.get("/analyze")

--- a/app/main.py
+++ b/app/main.py
@@ -208,6 +208,20 @@ def _unified_error(code: str, message: str, status_code: int = 400) -> JSONRespo
     )
 
 
+async def _parse_json_body(request: Request) -> dict:
+    """
+    统一 JSON body 解析兜底：坏 JSON / 非 object body 一律抛 ValueError，
+    由路由层捕获后返回 INVALID_ARGUMENT。
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        raise ValueError("Request body must be valid JSON")
+    if not isinstance(body, dict):
+        raise ValueError("Request body must be a JSON object, not array or scalar")
+    return body
+
+
 def _parse_insight_query_params(data: dict) -> tuple[int, int]:
     """与 §3.1 一致：since_days、limit 可选，非法则回退默认。"""
     since_days = data.get("since_days", 90)
@@ -224,15 +238,21 @@ async def repo_insight_issues_commits(request: Request):
     """§3.1 Issues + Commits 洞察（成员 B 数据形态；实现供 C 评分融合与前端展示）"""
     from app.services.issue_commit_insight_service import fetch_issue_commit_insight
 
-    data = await request.json()
+    try:
+        data = await _parse_json_body(request)
+    except ValueError as e:
+        return _unified_error("INVALID_ARGUMENT", str(e))
+
     repo_url = (data.get("repo_url") or data.get("url") or "").strip()
     if not repo_url:
         return _unified_error("INVALID_ARGUMENT", "repo_url is required")
 
     since_days, limit = _parse_insight_query_params(data)
 
-    payload = await fetch_issue_commit_insight(repo_url, since_days=since_days, limit=limit)
-    return _unified_success(payload)
+    result = await fetch_issue_commit_insight(repo_url, since_days=since_days, limit=limit)
+    if result.get("_upstream_error"):
+        return _unified_error("UPSTREAM_UNAVAILABLE", result["_upstream_error"], status_code=502)
+    return _unified_success({k: v for k, v in result.items() if not k.startswith("_")})
 
 
 @app.post("/api/repro/score")
@@ -240,7 +260,11 @@ async def repro_score(request: Request):
     """§3.2 可复现性评分"""
     from app.services.repro_score_service import compute_repro_score
 
-    data = await request.json()
+    try:
+        data = await _parse_json_body(request)
+    except ValueError as e:
+        return _unified_error("INVALID_ARGUMENT", str(e))
+
     session_id = data.get("session_id")
     repo_url = data.get("repo_url") or data.get("url")
 
@@ -269,7 +293,11 @@ async def paper_align(request: Request):
     """§3.3 论文-代码对齐"""
     from app.services.paper_align_service import compute_paper_alignment
 
-    data = await request.json()
+    try:
+        data = await _parse_json_body(request)
+    except ValueError as e:
+        return _unified_error("INVALID_ARGUMENT", str(e))
+
     paper_text = data.get("paper_text", "")
     session_id = data.get("session_id")
     repo_url = data.get("repo_url") or data.get("url")

--- a/app/schemas/repro.py
+++ b/app/schemas/repro.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+可复现评分 & 论文-代码对齐 数据模型
+
+与 docs/development_contract_v1.md §3.2 / §3.3 字段一一对应。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+# ============================================================
+# §3.2  POST /api/repro/score
+# ============================================================
+
+@dataclass
+class ScoreRisk:
+    title: str
+    reason: str
+    evidence_refs: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DimensionScores:
+    code_structure: float = 0.0
+    docs_quality: float = 0.0
+    env_readiness: float = 0.0
+    community_stability: float = 0.0
+
+
+@dataclass
+class ReproScoreResult:
+    overall_score: int                       # 0-100
+    overall_score_raw: float                 # 0-1
+    level: str                               # high / medium / low
+    quality_tier: str                        # gold / silver / bronze / rejected
+    dimension_scores: DimensionScores
+    dimension_scores_raw: DimensionScores
+    risks: List[ScoreRisk] = field(default_factory=list)
+    evidence_refs: List[str] = field(default_factory=list)
+    summary: str = ""
+
+    @staticmethod
+    def compute_level(raw: float) -> str:
+        if raw >= 0.80:
+            return "high"
+        if raw >= 0.60:
+            return "medium"
+        return "low"
+
+    @staticmethod
+    def compute_tier(raw: float) -> str:
+        if raw >= 0.90:
+            return "gold"
+        if raw >= 0.70:
+            return "silver"
+        if raw >= 0.50:
+            return "bronze"
+        return "rejected"
+
+    def to_dict(self) -> dict:
+        return {
+            "overall_score": self.overall_score,
+            "overall_score_raw": round(self.overall_score_raw, 4),
+            "level": self.level,
+            "quality_tier": self.quality_tier,
+            "dimension_scores": {
+                "code_structure": round(self.dimension_scores.code_structure * 100),
+                "docs_quality": round(self.dimension_scores.docs_quality * 100),
+                "env_readiness": round(self.dimension_scores.env_readiness * 100),
+                "community_stability": round(self.dimension_scores.community_stability * 100),
+            },
+            "dimension_scores_raw": {
+                "code_structure": round(self.dimension_scores_raw.code_structure, 4),
+                "docs_quality": round(self.dimension_scores_raw.docs_quality, 4),
+                "env_readiness": round(self.dimension_scores_raw.env_readiness, 4),
+                "community_stability": round(self.dimension_scores_raw.community_stability, 4),
+            },
+            "risks": [
+                {"title": r.title, "reason": r.reason, "evidence_refs": r.evidence_refs}
+                for r in self.risks
+            ],
+            "evidence_refs": self.evidence_refs,
+            "summary": self.summary,
+        }
+
+
+# ============================================================
+# §3.3  POST /api/paper/align
+# ============================================================
+
+@dataclass
+class AlignmentItem:
+    claim: str
+    status: str                              # aligned / partial / missing
+    matched_files: List[str] = field(default_factory=list)
+    matched_symbols: List[str] = field(default_factory=list)
+    evidence_excerpt: str = ""
+
+
+@dataclass
+class MissingClaim:
+    claim: str
+    reason: str = ""
+
+
+@dataclass
+class PaperAlignResult:
+    alignment_items: List[AlignmentItem] = field(default_factory=list)
+    missing_claims: List[MissingClaim] = field(default_factory=list)
+    confidence: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "alignment_items": [
+                {
+                    "claim": a.claim,
+                    "status": a.status,
+                    "matched_files": a.matched_files,
+                    "matched_symbols": a.matched_symbols,
+                    "evidence_excerpt": a.evidence_excerpt,
+                }
+                for a in self.alignment_items
+            ],
+            "missing_claims": [
+                {"claim": m.claim, "reason": m.reason}
+                for m in self.missing_claims
+            ],
+            "confidence": round(self.confidence, 4),
+        }

--- a/app/services/issue_commit_insight_service.py
+++ b/app/services/issue_commit_insight_service.py
@@ -128,6 +128,19 @@ def build_insight_payload(
     }
 
 
+def _empty_payload(*, degraded: bool = False, upstream_error: Optional[str] = None) -> Dict[str, Any]:
+    """构造空结构，附带失败语义标记。"""
+    out: Dict[str, Any] = {
+        "issue_risks": [],
+        "recent_feats": [],
+        "stats": dict(_EMPTY_STATS),
+        "degraded": degraded,
+    }
+    if upstream_error is not None:
+        out["_upstream_error"] = upstream_error
+    return out
+
+
 async def fetch_issue_commit_insight(
     repo_url: str,
     since_days: int = 90,
@@ -137,20 +150,22 @@ async def fetch_issue_commit_insight(
     拉取并结构化 Issues + Commits 洞察。
 
     Returns:
-        与 §3.1 `data` 字段同结构的 dict。失败时返回空结构（不抛给上层）。
+        与 §3.1 `data` 字段同结构的 dict。
+        额外字段:
+        - ``degraded`` (bool): True 表示上游部分/完全不可用，数据可能不完整。
+        - ``_upstream_error`` (str, 仅失败时存在): 内部标记，路由层据此返回
+          ``UPSTREAM_UNAVAILABLE`` 错误而非 ``success``；正常路径不包含此字段。
     """
     parsed = parse_repo_url(repo_url)
     if not parsed:
         logger.warning("issue_commit_insight: invalid repo_url")
-        return {"issue_risks": [], "recent_feats": [], "stats": dict(_EMPTY_STATS)}
+        return _empty_payload(upstream_error="invalid repo_url")
 
     since_days = max(1, min(since_days, 365))
     limit = max(1, min(limit, 500))
 
     since_dt = datetime.now(timezone.utc) - timedelta(days=since_days)
     since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    empty = {"issue_risks": [], "recent_feats": [], "stats": dict(_EMPTY_STATS)}
 
     try:
         client = get_github_client()
@@ -162,15 +177,17 @@ async def fetch_issue_commit_insight(
         raw_commits = await client.list_repo_commits(
             repo, since=since_str, per_page=100, max_items=limit
         )
-        return build_insight_payload(
+        result = build_insight_payload(
             raw_issues,
             raw_commits,
             limit_issues=limit,
             limit_commits=limit,
         )
+        result["degraded"] = False
+        return result
     except GitHubError as e:
         logger.warning("issue_commit_insight GitHubError: %s", e)
-        return empty
+        return _empty_payload(upstream_error=f"GitHub API error: {e.message}")
     except Exception as e:
         logger.warning("issue_commit_insight failed: %s", e, exc_info=True)
-        return empty
+        return _empty_payload(upstream_error=f"Unexpected error: {e}")

--- a/app/services/issue_commit_insight_service.py
+++ b/app/services/issue_commit_insight_service.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+Issues + Commits 洞察（契约 §3.1 data 形状）
+
+供：
+- POST /api/repo/insight/issues-commits 直接返回
+- repro_score_service 融合可复现评分
+
+HTTP 调用走 GitHubClient（成员 B 维护的客户端扩展）。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+
+from app.utils.github_client import get_github_client, parse_repo_url, GitHubError
+
+logger = logging.getLogger(__name__)
+
+_EMPTY_STATS = {
+    "issues_total_scanned": 0,
+    "commits_total_scanned": 0,
+    "risk_issue_count": 0,
+    "recent_feat_count": 0,
+}
+
+_REPRO_PAT = re.compile(
+    r"reproduc|cannot\s+repro|can\'?t\s+repro|repro\s|cuda|docker|"
+    r"dependenc|pip\s|conda|environment|venv|build\s+fail|install\s+fail|"
+    r"wheel|version\s+mismatch|requirements",
+    re.IGNORECASE,
+)
+_FEAT_MSG = re.compile(r"^(feat|feature)(\(|!|:|\b)", re.IGNORECASE)
+
+
+def _utc_iso_z(dt: Optional[str]) -> str:
+    if not dt:
+        return ""
+    s = dt.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(s)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception:
+        return dt if dt.endswith("Z") else f"{dt}Z"
+
+
+def _issue_risk_entry(issue: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    title = (issue.get("title") or "")[:500]
+    body = (issue.get("body") or "")[:2000]
+    labels = [str(l.get("name", "")).lower() for l in issue.get("labels", []) if isinstance(l, dict)]
+    text = f"{title}\n{body}\n{' '.join(labels)}"
+
+    if not _REPRO_PAT.search(text) and not any(
+        x in labels for x in ("bug", "reproducibility", "dependencies", "installation")
+    ):
+        return None
+
+    if _REPRO_PAT.search(text) or "reproducibility" in labels:
+        risk_type = "repro_env"
+        severity = "high" if re.search(r"cuda|docker|dependenc|reproduc", text, re.I) else "medium"
+    else:
+        risk_type = "stability"
+        severity = "high" if "critical" in labels or "blocker" in labels else "medium"
+
+    return {
+        "id": issue.get("number", 0),
+        "title": title,
+        "url": issue.get("html_url", ""),
+        "labels": [l.get("name", "") for l in issue.get("labels", []) if isinstance(l, dict)],
+        "risk_type": risk_type,
+        "severity": severity,
+    }
+
+
+def _commit_feat_entry(c: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    commit = c.get("commit") or {}
+    msg = (commit.get("message") or "").strip()
+    first = msg.split("\n", 1)[0].strip()
+    if not _FEAT_MSG.match(first):
+        return None
+    author = commit.get("author") or {}
+    sha = (c.get("sha") or "")[:7]
+    return {
+        "sha": sha,
+        "message": first[:500],
+        "author": (author.get("name") or "unknown")[:120],
+        "date": _utc_iso_z(author.get("date")),
+        "category": "feature",
+    }
+
+
+def build_insight_payload(
+    raw_issues: List[Dict[str, Any]],
+    raw_commits: List[Dict[str, Any]],
+    *,
+    limit_issues: int,
+    limit_commits: int,
+) -> Dict[str, Any]:
+    """将 GitHub 原始 JSON 转为 §3.1 的 data 对象。"""
+    issue_risks: List[Dict[str, Any]] = []
+    for issue in raw_issues[:limit_issues]:
+        row = _issue_risk_entry(issue)
+        if row:
+            issue_risks.append(row)
+
+    recent_feats: List[Dict[str, Any]] = []
+    for c in raw_commits[:limit_commits]:
+        row = _commit_feat_entry(c)
+        if row:
+            recent_feats.append(row)
+
+    return {
+        "issue_risks": issue_risks,
+        "recent_feats": recent_feats,
+        "stats": {
+            "issues_total_scanned": len(raw_issues),
+            "commits_total_scanned": len(raw_commits),
+            "risk_issue_count": len(issue_risks),
+            "recent_feat_count": len(recent_feats),
+        },
+    }
+
+
+async def fetch_issue_commit_insight(
+    repo_url: str,
+    since_days: int = 90,
+    limit: int = 100,
+) -> Dict[str, Any]:
+    """
+    拉取并结构化 Issues + Commits 洞察。
+
+    Returns:
+        与 §3.1 `data` 字段同结构的 dict。失败时返回空结构（不抛给上层）。
+    """
+    parsed = parse_repo_url(repo_url)
+    if not parsed:
+        logger.warning("issue_commit_insight: invalid repo_url")
+        return {"issue_risks": [], "recent_feats": [], "stats": dict(_EMPTY_STATS)}
+
+    since_days = max(1, min(since_days, 365))
+    limit = max(1, min(limit, 500))
+
+    since_dt = datetime.now(timezone.utc) - timedelta(days=since_days)
+    since_str = since_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    empty = {"issue_risks": [], "recent_feats": [], "stats": dict(_EMPTY_STATS)}
+
+    try:
+        client = get_github_client()
+        owner, name = parsed
+        repo = await client.get_repo(owner, name)
+        raw_issues = await client.list_repo_issues_open(
+            repo, since=since_str, per_page=100, max_items=limit
+        )
+        raw_commits = await client.list_repo_commits(
+            repo, since=since_str, per_page=100, max_items=limit
+        )
+        return build_insight_payload(
+            raw_issues,
+            raw_commits,
+            limit_issues=limit,
+            limit_commits=limit,
+        )
+    except GitHubError as e:
+        logger.warning("issue_commit_insight GitHubError: %s", e)
+        return empty
+    except Exception as e:
+        logger.warning("issue_commit_insight failed: %s", e, exc_info=True)
+        return empty

--- a/app/services/paper_align_service.py
+++ b/app/services/paper_align_service.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""
+论文-代码对齐服务  (Owner: 成员 C)
+
+职责:
+- 从 paper_text 拆分可验证 claims
+- 利用向量检索 (search_hybrid) 在已索引仓库中查找代码证据
+- LLM 判定 aligned / partial / missing
+- 输出 PaperAlignResult (与 §3.3 对齐)
+
+不负责:
+- GitHub Issues/Commits 抽取 (成员 B)
+- 路由注册 (成员 A)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Dict, List, Optional
+
+from app.core.config import settings
+from app.schemas.repro import (
+    AlignmentItem,
+    MissingClaim,
+    PaperAlignResult,
+)
+from app.services.vector_service import store_manager
+from app.utils.llm_client import get_client
+from app.utils.session import generate_repo_session_id
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+# Step 1: LLM 拆 claim
+# ------------------------------------------------------------------
+
+_EXTRACT_CLAIMS_PROMPT = """\
+You are a research paper analyst. Given a paper excerpt, extract a list of \
+**verifiable technical claims** that could be checked against a code repository.
+
+Focus on claims about:
+- Algorithms, models, architectures
+- Training/evaluation pipelines
+- Data processing steps
+- Specific techniques or optimizations
+
+## Paper Text
+{paper_text}
+
+## Instructions
+Return **valid JSON only** (no markdown fences). Schema:
+{{
+  "claims": [
+    "claim text 1",
+    "claim text 2"
+  ]
+}}
+Extract at most 10 claims. Each claim should be a single concise sentence.
+"""
+
+
+async def _extract_claims(paper_text: str) -> List[str]:
+    client = get_client()
+    if not client:
+        logger.warning("LLM client unavailable; cannot extract claims")
+        return []
+
+    prompt = _EXTRACT_CLAIMS_PROMPT.format(paper_text=paper_text[:6000])
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.default_model_name,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+            max_tokens=1024,
+            stream=False,
+        )
+        raw = response.choices[0].message.content.strip()
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw)
+        data = json.loads(raw)
+        claims: List[str] = data.get("claims", [])
+        return [c for c in claims if isinstance(c, str) and c.strip()]
+    except Exception as e:
+        logger.error("Claim extraction failed: %s", e, exc_info=True)
+        return []
+
+
+# ------------------------------------------------------------------
+# Step 2: 检索 + LLM 对齐判定 (per claim)
+# ------------------------------------------------------------------
+
+_ALIGN_JUDGE_PROMPT = """\
+You are a code-paper alignment judge. Determine whether the following code \
+evidence supports the claim from a research paper.
+
+## Claim
+{claim}
+
+## Code Evidence (top snippets from the repository)
+{evidence}
+
+## Instructions
+Return **valid JSON only** (no markdown fences). Schema:
+{{
+  "status": "aligned" | "partial" | "missing",
+  "matched_files": ["file1.py", ...],
+  "matched_symbols": ["function_or_class_name", ...],
+  "evidence_excerpt": "key code line(s) that support the claim (max 200 chars)",
+  "reason": "brief justification"
+}}
+- "aligned": code clearly implements the claim
+- "partial": some evidence but incomplete or indirect
+- "missing": no supporting code found
+"""
+
+
+async def _judge_claim(
+    claim: str,
+    evidence_snippets: List[Dict],
+) -> AlignmentItem | MissingClaim:
+    """Use LLM to judge whether evidence supports a single claim."""
+    client = get_client()
+    if not client:
+        return MissingClaim(claim=claim, reason="LLM unavailable")
+
+    evidence_text = "\n---\n".join(
+        f"File: {s.get('file', '?')}\n{s.get('content', '')[:800]}"
+        for s in evidence_snippets[:5]
+    )
+    if not evidence_text.strip():
+        return MissingClaim(claim=claim, reason="no code indexed or search returned nothing")
+
+    prompt = _ALIGN_JUDGE_PROMPT.format(
+        claim=claim,
+        evidence=evidence_text[:4000],
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.default_model_name,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+            max_tokens=512,
+            stream=False,
+        )
+        raw = response.choices[0].message.content.strip()
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw)
+        data = json.loads(raw)
+
+        status = data.get("status", "missing")
+        if status == "missing":
+            return MissingClaim(
+                claim=claim,
+                reason=data.get("reason", "no direct implementation evidence found"),
+            )
+        return AlignmentItem(
+            claim=claim,
+            status=status,
+            matched_files=data.get("matched_files", []),
+            matched_symbols=data.get("matched_symbols", []),
+            evidence_excerpt=data.get("evidence_excerpt", "")[:300],
+        )
+    except Exception as e:
+        logger.error("Alignment judge failed for claim '%s': %s", claim[:60], e)
+        return MissingClaim(claim=claim, reason=f"LLM judge error: {e}")
+
+
+# ------------------------------------------------------------------
+# 公开 API
+# ------------------------------------------------------------------
+
+def _resolve_session(
+    session_id: Optional[str],
+    repo_url: Optional[str],
+) -> str:
+    if session_id:
+        return session_id
+    if repo_url:
+        return generate_repo_session_id(repo_url)
+    raise ValueError("session_id 或 repo_url 至少提供一个")
+
+
+async def compute_paper_alignment(
+    paper_text: str,
+    session_id: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    top_k: int = 5,
+) -> PaperAlignResult:
+    """
+    论文-代码对齐 (§3.3)。
+
+    Args:
+        paper_text: 论文 / 方法描述文本
+        session_id: 仓库 session
+        repo_url:   备选，推导 session_id
+        top_k:      每条 claim 检索的代码片段数
+
+    Returns:
+        PaperAlignResult
+    """
+    if not paper_text or not paper_text.strip():
+        raise ValueError("paper_text is required")
+    top_k = max(1, min(top_k, 20))
+
+    sid = _resolve_session(session_id, repo_url)
+    store = store_manager.get_store(sid)
+    context = store.load_context()
+    if not context or not context.get("repo_url"):
+        raise ValueError(f"Session {sid} has no analyzed context. Run /analyze first.")
+
+    # Step 1: 拆 claim
+    claims = await _extract_claims(paper_text)
+    if not claims:
+        return PaperAlignResult(
+            missing_claims=[MissingClaim(claim="(entire paper)", reason="failed to extract claims")],
+            confidence=0.0,
+        )
+
+    # Step 2 & 3: 逐条检索 + 判定
+    alignment_items: List[AlignmentItem] = []
+    missing_claims: List[MissingClaim] = []
+
+    for claim in claims:
+        snippets = await store.search_hybrid(claim, top_k=top_k)
+        result = await _judge_claim(claim, snippets)
+        if isinstance(result, AlignmentItem):
+            alignment_items.append(result)
+        else:
+            missing_claims.append(result)
+
+    # confidence = aligned 占比 (aligned=1, partial=0.5, missing=0)
+    total = len(claims) or 1
+    aligned_score = sum(
+        1.0 if a.status == "aligned" else 0.5
+        for a in alignment_items
+    )
+    confidence = round(aligned_score / total, 4)
+
+    return PaperAlignResult(
+        alignment_items=alignment_items,
+        missing_claims=missing_claims,
+        confidence=confidence,
+    )

--- a/app/services/paper_align_service.py
+++ b/app/services/paper_align_service.py
@@ -151,7 +151,10 @@ async def _judge_claim(
         raw = re.sub(r"\s*```$", "", raw)
         data = json.loads(raw)
 
-        status = data.get("status", "missing")
+        _VALID_STATUSES = {"aligned", "partial", "missing"}
+        raw_status = data.get("status", "missing")
+        status = raw_status if raw_status in _VALID_STATUSES else "missing"
+
         if status == "missing":
             return MissingClaim(
                 claim=claim,

--- a/app/services/repro_score_service.py
+++ b/app/services/repro_score_service.py
@@ -288,17 +288,20 @@ async def compute_repro_score(
     effective_repo_url: str = context.get("repo_url") or ""
 
     # 0. GitHub insight（§3.1，与 §4「C 接入 insight」对齐）
-    insight: Dict[str, Any] = {"issue_risks": [], "recent_feats": [], "stats": {}}
+    #    _upstream_error 存在时说明 GitHub 不可达，评分降级：仅用规则+报告，不惩罚维度。
+    insight: Dict[str, Any] = {"issue_risks": [], "recent_feats": [], "stats": {}, "degraded": True}
     if effective_repo_url:
         insight = await fetch_issue_commit_insight(
             effective_repo_url,
             since_days=insight_since_days,
             limit=insight_limit,
         )
+    insight_degraded = bool(insight.get("degraded") or insight.get("_upstream_error"))
 
-    # 1. 规则打分 + insight 校正
+    # 1. 规则打分 + insight 校正（降级时跳过 insight 惩罚）
     dim_raw = _rule_based_scores(file_tree)
-    dim_raw = _adjust_scores_for_insight(dim_raw, insight)
+    if not insight_degraded:
+        dim_raw = _adjust_scores_for_insight(dim_raw, insight)
     overall_raw = _aggregate(dim_raw)
 
     # 2. LLM 生成 risks / summary（含 insight JSON）

--- a/app/services/repro_score_service.py
+++ b/app/services/repro_score_service.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+"""
+可复现性评分服务  (Owner: 成员 C)
+
+职责:
+- 读取 session 已有上下文 (file_tree / report / summary)
+- 规则层：检测关键文件→四维度打分
+- LLM 层：生成 risks 列表与 summary 文本
+- 输出 ReproScoreResult (与 §3.2 对齐)
+
+不负责:
+- GitHub Issues/Commits 的底层 API 客户端实现 (见 github_client；抽取编排在本仓库 issue_commit_insight_service)
+- 路由注册 (成员 A)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from app.core.config import settings
+from app.schemas.repro import (
+    DimensionScores,
+    ReproScoreResult,
+    ScoreRisk,
+)
+from app.services.vector_service import store_manager
+from app.services.issue_commit_insight_service import fetch_issue_commit_insight
+from app.utils.llm_client import get_client
+from app.utils.session import generate_repo_session_id
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+# 规则层：关键文件 / 模式 → 维度分数 (0-1)
+# ------------------------------------------------------------------
+
+_CODE_STRUCTURE_SIGNALS: List[Dict[str, Any]] = [
+    {"pattern": r"(src|lib|app|pkg|cmd)/", "weight": 0.25, "label": "organised src dir"},
+    {"pattern": r"(main|index|__main__)\.(py|ts|js|go|rs)$", "weight": 0.20, "label": "entry point"},
+    {"pattern": r"tests?/|_test\.(py|go|rs)$|\.test\.(ts|js)$", "weight": 0.20, "label": "test dir"},
+    {"pattern": r"(Makefile|justfile|taskfile\.yml)$", "weight": 0.15, "label": "build script"},
+    {"pattern": r"\.github/workflows/", "weight": 0.10, "label": "CI workflow"},
+    {"pattern": r"(setup\.py|pyproject\.toml|Cargo\.toml|go\.mod|package\.json|pom\.xml)$",
+     "weight": 0.10, "label": "manifest"},
+]
+
+_DOCS_SIGNALS: List[Dict[str, Any]] = [
+    {"pattern": r"README(\.\w+)?$", "weight": 0.35, "label": "README"},
+    {"pattern": r"(CONTRIBUTING|CHANGELOG|HISTORY)(\.\w+)?$", "weight": 0.15, "label": "contrib/changelog"},
+    {"pattern": r"(docs?|documentation)/", "weight": 0.20, "label": "docs dir"},
+    {"pattern": r"LICENSE(\.\w+)?$", "weight": 0.15, "label": "LICENSE"},
+    {"pattern": r"(examples?|tutorials?|notebooks?)/", "weight": 0.15, "label": "examples"},
+]
+
+_ENV_SIGNALS: List[Dict[str, Any]] = [
+    {"pattern": r"(requirements.*\.txt|Pipfile|poetry\.lock|setup\.cfg|pyproject\.toml|go\.sum|Cargo\.lock|package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$",
+     "weight": 0.30, "label": "lock / deps"},
+    {"pattern": r"Dockerfile|docker-compose", "weight": 0.25, "label": "Docker"},
+    {"pattern": r"\.env\.example|\.env\.sample", "weight": 0.15, "label": ".env template"},
+    {"pattern": r"(Makefile|scripts/.*\.(sh|bash))$", "weight": 0.15, "label": "setup scripts"},
+    {"pattern": r"(setup\.py|pyproject\.toml|Cargo\.toml|go\.mod|package\.json)$",
+     "weight": 0.15, "label": "manifest (env)"},
+]
+
+# community_stability 规则层；§4 要求再融合 GitHub insight（issue_commit_insight_service）
+_COMMUNITY_SIGNALS: List[Dict[str, Any]] = [
+    {"pattern": r"\.github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)", "weight": 0.25, "label": "issue/PR template"},
+    {"pattern": r"(CONTRIBUTING|CODE_OF_CONDUCT)(\.\w+)?$", "weight": 0.25, "label": "community docs"},
+    {"pattern": r"\.github/workflows/", "weight": 0.20, "label": "CI (community)"},
+    {"pattern": r"SECURITY(\.\w+)?$", "weight": 0.15, "label": "security policy"},
+    {"pattern": r"(CHANGELOG|HISTORY)(\.\w+)?$", "weight": 0.15, "label": "changelog"},
+]
+
+
+def _score_dimension(file_tree: str, signals: List[Dict[str, Any]]) -> float:
+    """按信号权重叠加打分，命中一个信号即得该 weight，最终 clamp 到 [0, 1]。"""
+    score = 0.0
+    for sig in signals:
+        if re.search(sig["pattern"], file_tree, re.IGNORECASE | re.MULTILINE):
+            score += sig["weight"]
+    return min(score, 1.0)
+
+
+def _rule_based_scores(file_tree: str) -> DimensionScores:
+    return DimensionScores(
+        code_structure=_score_dimension(file_tree, _CODE_STRUCTURE_SIGNALS),
+        docs_quality=_score_dimension(file_tree, _DOCS_SIGNALS),
+        env_readiness=_score_dimension(file_tree, _ENV_SIGNALS),
+        community_stability=_score_dimension(file_tree, _COMMUNITY_SIGNALS),
+    )
+
+
+def _aggregate(dim: DimensionScores) -> float:
+    """四维度等权平均 → overall_score_raw (0-1)。"""
+    values = [dim.code_structure, dim.docs_quality, dim.env_readiness, dim.community_stability]
+    return sum(values) / len(values)
+
+
+def _adjust_scores_for_insight(dim: DimensionScores, insight: Dict[str, Any]) -> DimensionScores:
+    """根据 §3.1 insight 下调 community / env（开放风险 issue 越多惩罚越大，有上限）。"""
+    stats = insight.get("stats") or {}
+    risks_n = int(stats.get("risk_issue_count", 0) or 0)
+    scanned = int(stats.get("issues_total_scanned", 0) or 0)
+    high_repro = sum(
+        1
+        for it in insight.get("issue_risks", [])
+        if isinstance(it, dict)
+        and it.get("risk_type") == "repro_env"
+        and str(it.get("severity", "")).lower() == "high"
+    )
+
+    risk_rate = (risks_n / scanned) if scanned else 0.0
+    comm_penalty = min(0.38, risks_n * 0.045 + risk_rate * 0.22)
+    env_penalty = min(0.28, high_repro * 0.07 + risks_n * 0.025)
+
+    return DimensionScores(
+        code_structure=dim.code_structure,
+        docs_quality=dim.docs_quality,
+        env_readiness=max(0.0, dim.env_readiness - env_penalty),
+        community_stability=max(0.0, dim.community_stability - comm_penalty),
+    )
+
+
+def _risks_from_insight(insight: Dict[str, Any], max_items: int = 8) -> List[ScoreRisk]:
+    out: List[ScoreRisk] = []
+    for it in (insight.get("issue_risks") or [])[:max_items]:
+        if not isinstance(it, dict):
+            continue
+        iid = it.get("id")
+        url = it.get("url") or ""
+        ref = f"issue#{iid}" if iid is not None else url
+        out.append(
+            ScoreRisk(
+                title=str(it.get("title", "open issue"))[:200],
+                reason=f"GitHub {it.get('risk_type', 'risk')} ({it.get('severity', 'unknown')}): see issue tracker",
+                evidence_refs=[ref] if ref else [],
+            )
+        )
+    return out
+
+
+def _insight_evidence_refs(insight: Dict[str, Any], max_each: int = 15) -> List[str]:
+    refs: List[str] = []
+    for it in (insight.get("issue_risks") or [])[:max_each]:
+        if isinstance(it, dict) and it.get("id") is not None:
+            refs.append(f"issue#{it['id']}")
+    for ft in (insight.get("recent_feats") or [])[:max_each]:
+        if isinstance(ft, dict) and ft.get("sha"):
+            refs.append(f"commit:{ft['sha']}")
+    return refs
+
+
+# ------------------------------------------------------------------
+# LLM 层：生成 risks + summary
+# ------------------------------------------------------------------
+
+_RISK_PROMPT = """\
+You are a reproducibility auditor. Given the repository file tree, an analysis report, \
+and optional GitHub issue/commit signals (JSON), identify **reproducibility risks** and write a brief summary.
+
+## File Tree
+{file_tree}
+
+## Analysis Report (truncated)
+{report}
+
+## GitHub Insight (issues/commits summary, may be empty)
+{insight_json}
+
+## Instructions
+Return **valid JSON only** (no markdown fences). Schema:
+{{
+  "risks": [
+    {{
+      "title": "short title",
+      "reason": "why this is a risk",
+      "evidence_refs": ["file or issue ref"]
+    }}
+  ],
+  "summary": "1-2 sentence overall reproducibility assessment"
+}}
+If no risks, return {{"risks": [], "summary": "..."}}.
+"""
+
+
+async def _llm_risks_and_summary(
+    file_tree: str,
+    report: str,
+    insight: Dict[str, Any],
+) -> tuple[List[ScoreRisk], str]:
+    """Call LLM to generate risk list and summary."""
+    client = get_client()
+    if not client:
+        logger.warning("LLM client unavailable; skipping risk analysis")
+        return [], "LLM unavailable – rule-based score only."
+
+    try:
+        insight_json = json.dumps(insight, ensure_ascii=False)[:3500]
+    except Exception:
+        insight_json = "{}"
+
+    prompt = _RISK_PROMPT.format(
+        file_tree=file_tree[:6000],
+        report=report[:4000],
+        insight_json=insight_json,
+    )
+
+    try:
+        response = await client.chat.completions.create(
+            model=settings.default_model_name,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+            max_tokens=1024,
+            stream=False,
+        )
+        raw = response.choices[0].message.content.strip()
+        # strip markdown fences if present
+        raw = re.sub(r"^```(?:json)?\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw)
+        data = json.loads(raw)
+
+        risks = [
+            ScoreRisk(
+                title=r.get("title", ""),
+                reason=r.get("reason", ""),
+                evidence_refs=r.get("evidence_refs", []),
+            )
+            for r in data.get("risks", [])
+        ]
+        summary = data.get("summary", "")
+        return risks, summary
+
+    except Exception as e:
+        logger.error("LLM risk analysis failed: %s", e, exc_info=True)
+        return [], "Risk analysis unavailable due to LLM error."
+
+
+# ------------------------------------------------------------------
+# 公开 API
+# ------------------------------------------------------------------
+
+def _resolve_session(
+    session_id: Optional[str],
+    repo_url: Optional[str],
+) -> str:
+    """从 session_id 或 repo_url 推导出有效 session_id。"""
+    if session_id:
+        return session_id
+    if repo_url:
+        return generate_repo_session_id(repo_url)
+    raise ValueError("session_id 和 repo_url 至少提供一个")
+
+
+async def compute_repro_score(
+    session_id: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    *,
+    insight_since_days: int = 90,
+    insight_limit: int = 100,
+) -> ReproScoreResult:
+    """
+    计算仓库可复现性评分 (§3.2)。
+
+    Args:
+        session_id: 仓库 session（优先）
+        repo_url:   仓库 URL（备选，可用于推导 session_id）
+        insight_since_days: 拉取 GitHub insight 的时间窗（天），默认 90，范围 1–365
+        insight_limit: 单次拉取的 issue/commit 条数上限，默认 100，范围 1–500
+
+    Returns:
+        ReproScoreResult
+
+    Raises:
+        ValueError: session 无上下文（仓库未分析）
+    """
+    sid = _resolve_session(session_id, repo_url)
+    store = store_manager.get_store(sid)
+    context = store.load_context()
+    if not context or not context.get("repo_url"):
+        raise ValueError(f"Session {sid} has no analyzed context. Run /analyze first.")
+
+    global_ctx = context.get("global_context", {})
+    file_tree: str = global_ctx.get("file_tree", "")
+    report: str = store.get_report("en") or store.get_report("zh") or ""
+    effective_repo_url: str = context.get("repo_url") or ""
+
+    # 0. GitHub insight（§3.1，与 §4「C 接入 insight」对齐）
+    insight: Dict[str, Any] = {"issue_risks": [], "recent_feats": [], "stats": {}}
+    if effective_repo_url:
+        insight = await fetch_issue_commit_insight(
+            effective_repo_url,
+            since_days=insight_since_days,
+            limit=insight_limit,
+        )
+
+    # 1. 规则打分 + insight 校正
+    dim_raw = _rule_based_scores(file_tree)
+    dim_raw = _adjust_scores_for_insight(dim_raw, insight)
+    overall_raw = _aggregate(dim_raw)
+
+    # 2. LLM 生成 risks / summary（含 insight JSON）
+    risks, summary = await _llm_risks_and_summary(file_tree, report, insight)
+
+    # 2b. 合并 issue 风险（置前，便于阅读）
+    insight_risks = _risks_from_insight(insight)
+    risks = insight_risks + risks
+
+    # 3. 收集 evidence_refs（来自 file_tree 中检测到的关键文件）
+    evidence: List[str] = []
+    for pattern, label in [
+        (r"README(\.\w+)?", "README"),
+        (r"requirements.*\.txt", "requirements.txt"),
+        (r"Dockerfile", "Dockerfile"),
+        (r"setup\.py|pyproject\.toml", "setup/pyproject"),
+    ]:
+        m = re.search(pattern, file_tree, re.IGNORECASE)
+        if m:
+            evidence.append(m.group(0))
+
+    for r in risks:
+        evidence.extend(r.evidence_refs)
+    evidence.extend(_insight_evidence_refs(insight))
+    evidence = list(dict.fromkeys(evidence))  # deduplicate, preserve order
+
+    result = ReproScoreResult(
+        overall_score=round(overall_raw * 100),
+        overall_score_raw=overall_raw,
+        level=ReproScoreResult.compute_level(overall_raw),
+        quality_tier=ReproScoreResult.compute_tier(overall_raw),
+        dimension_scores=DimensionScores(
+            code_structure=dim_raw.code_structure,
+            docs_quality=dim_raw.docs_quality,
+            env_readiness=dim_raw.env_readiness,
+            community_stability=dim_raw.community_stability,
+        ),
+        dimension_scores_raw=dim_raw,
+        risks=risks,
+        evidence_refs=evidence,
+        summary=summary,
+    )
+    return result

--- a/app/utils/github_client.py
+++ b/app/utils/github_client.py
@@ -573,6 +573,88 @@ class GitHubClient:
         
         return content_map
 
+    # --------------------------------------------------------
+    # Issues / Commits（供 issue_commit_insight_service §3.1 使用）
+    # --------------------------------------------------------
+
+    async def list_repo_issues_open(
+        self,
+        repo: GitHubRepo,
+        *,
+        since: Optional[str] = None,
+        per_page: int = 100,
+        max_items: int = 500,
+    ) -> List[Dict[str, Any]]:
+        """
+        列出仓库 open issues（不含 PR）。支持分页，最多 max_items 条。
+
+        Args:
+            since: ISO8601 UTC，仅返回此时间之后有更新的 issue（GitHub API 语义）
+        """
+        out: List[Dict[str, Any]] = []
+        page = 1
+        per_page = min(per_page, 100)
+        while len(out) < max_items:
+            params: Dict[str, Any] = {
+                "state": "open",
+                "per_page": per_page,
+                "page": page,
+            }
+            if since:
+                params["since"] = since
+            data = await self._request(
+                "GET",
+                f"/repos/{repo.owner}/{repo.name}/issues",
+                params=params,
+            )
+            if not isinstance(data, list) or not data:
+                break
+            for item in data:
+                if "pull_request" in item:
+                    continue
+                out.append(item)
+                if len(out) >= max_items:
+                    break
+            if len(data) < per_page:
+                break
+            page += 1
+        return out[:max_items]
+
+    async def list_repo_commits(
+        self,
+        repo: GitHubRepo,
+        *,
+        since: Optional[str] = None,
+        per_page: int = 100,
+        max_items: int = 500,
+        sha: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """列出提交（默认默认分支），支持 since（ISO8601）与分页。"""
+        out: List[Dict[str, Any]] = []
+        page = 1
+        per_page = min(per_page, 100)
+        branch = sha or repo.default_branch
+        while len(out) < max_items:
+            params: Dict[str, Any] = {
+                "sha": branch,
+                "per_page": per_page,
+                "page": page,
+            }
+            if since:
+                params["since"] = since
+            data = await self._request(
+                "GET",
+                f"/repos/{repo.owner}/{repo.name}/commits",
+                params=params,
+            )
+            if not isinstance(data, list) or not data:
+                break
+            out.extend(data)
+            if len(data) < per_page:
+                break
+            page += 1
+        return out[:max_items]
+
 
 # ============================================================
 # 全局单例管理

--- a/docs/development_contract_v1.md
+++ b/docs/development_contract_v1.md
@@ -134,13 +134,17 @@
 ```json
 {
   "session_id": "repo_xxx",
-  "repo_url": "https://github.com/owner/repo"
+  "repo_url": "https://github.com/owner/repo",
+  "since_days": 90,
+  "limit": 100
 }
 ```
 
 字段约束：
 1. `session_id`、`repo_url` 至少提供一个。  
 2. 如仅提供 `repo_url`，服务端可生成对应 `session_id`。  
+3. `since_days`：可选，默认 `90`，范围 `1-365`；用于拉取 GitHub Issues/Commits 洞察（与 §3.1 同源）并参与评分融合。  
+4. `limit`：可选，默认 `100`，范围 `1-500`；单次扫描的 issue/commit 条数上限。  
 
 ### Response
 

--- a/docs/part_c_interface.md
+++ b/docs/part_c_interface.md
@@ -1,0 +1,284 @@
+# Part C —— 可复现评分 & 论文-代码对齐
+
+> Owner：成员 C  
+> 依赖：已完成 `/analyze` 的仓库 session  
+> 契约版本：V1.1（`docs/development_contract_v1.md` §3.2 / §3.3）
+
+---
+
+## 1. 文件清单
+
+| 文件 | 作用 |
+|------|------|
+| `app/schemas/repro.py` | 数据模型：`ReproScoreResult`、`PaperAlignResult` 等 |
+| `app/services/repro_score_service.py` | 可复现评分核心逻辑 |
+| `app/services/paper_align_service.py` | 论文-代码对齐核心逻辑 |
+| `app/main.py`（增量） | 路由 `POST /api/repro/score`、`POST /api/paper/align` |
+| `tests/conftest.py` | 测试 stub（qdrant_client 等离线 mock） |
+| `tests/test_part_c.py` | 单元测试（20 条，全 mock，离线可跑） |
+
+---
+
+## 2. 接口说明
+
+### 2.1 `POST /api/repro/score` — 可复现性评分
+
+**请求**
+
+```json
+{
+  "session_id": "repo_xxx",
+  "repo_url": "https://github.com/owner/repo",
+  "since_days": 90,
+  "limit": 100
+}
+```
+
+- `session_id` / `repo_url` 至少提供一个（两者都给以 `session_id` 优先）。
+- `repo_url` 也接受 `url` 作为别名。
+- `since_days`（可选，默认 90，1–365）、`limit`（可选，默认 100，1–500）：控制拉取 GitHub insight 的时间窗与条数，与 `POST /api/repo/insight/issues-commits` 语义一致；非法值回退默认。
+
+**响应**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "overall_score": 72,
+    "overall_score_raw": 0.72,
+    "level": "medium",
+    "quality_tier": "silver",
+    "dimension_scores": {
+      "code_structure": 80,
+      "docs_quality": 68,
+      "env_readiness": 70,
+      "community_stability": 66
+    },
+    "dimension_scores_raw": {
+      "code_structure": 0.8,
+      "docs_quality": 0.68,
+      "env_readiness": 0.7,
+      "community_stability": 0.66
+    },
+    "risks": [
+      {
+        "title": "CUDA version conflict",
+        "reason": "multiple open issues about dependency conflicts",
+        "evidence_refs": ["issue#123", "Dockerfile"]
+      }
+    ],
+    "evidence_refs": ["README.md", "requirements.txt", "Dockerfile"],
+    "summary": "Repository is partially reproducible with moderate setup risk."
+  },
+  "error": null
+}
+```
+
+**评分逻辑**
+
+| 层级 | 说明 |
+|------|------|
+| **规则层** | 用正则扫描 `file_tree`，按信号权重累加四维度分数（0-1）。 |
+| **LLM 层** | 发送 `file_tree` + 分析报告给 LLM，返回 `risks` 列表和 `summary`。 |
+| **降级** | LLM 不可用时仍返回规则层打分，`summary` 标记为 unavailable。 |
+
+四维度说明：
+
+| 维度 | 主要检测信号 |
+|------|-------------|
+| `code_structure` | src/lib 目录、入口文件、测试目录、CI、构建脚本、manifest |
+| `docs_quality` | README、LICENSE、docs 目录、CONTRIBUTING、examples |
+| `env_readiness` | 依赖锁文件、Dockerfile、.env.example、安装脚本 |
+| `community_stability` | issue/PR 模板、CONTRIBUTING、CI、SECURITY、CHANGELOG |
+
+---
+
+### 2.2 `POST /api/paper/align` — 论文-代码对齐
+
+**请求**
+
+```json
+{
+  "session_id": "repo_xxx",
+  "paper_text": "We propose a two-stage retrieval pipeline...",
+  "top_k": 5
+}
+```
+
+- `paper_text`：必填。
+- `session_id` / `repo_url`：至少提供一个。
+- `top_k`：可选，默认 5，范围 1-20。
+
+**响应**
+
+```json
+{
+  "status": "success",
+  "data": {
+    "alignment_items": [
+      {
+        "claim": "The system uses a two-stage retrieval pipeline.",
+        "status": "aligned",
+        "matched_files": ["src/model.py"],
+        "matched_symbols": ["TwoStageRetriever", "search_hybrid"],
+        "evidence_excerpt": "class TwoStageRetriever … def search_hybrid"
+      }
+    ],
+    "missing_claims": [
+      {
+        "claim": "Ablation on model X",
+        "reason": "no direct implementation evidence found"
+      }
+    ],
+    "confidence": 0.78
+  },
+  "error": null
+}
+```
+
+**对齐逻辑**
+
+```
+paper_text ──▶ LLM 拆 claim（≤10 条）
+                 │
+                 ▼
+         逐条 search_hybrid 检索代码片段
+                 │
+                 ▼
+         LLM 判定 aligned / partial / missing
+                 │
+                 ▼
+         汇总 → confidence = Σ(aligned×1 + partial×0.5) / total
+```
+
+---
+
+## 3. 错误响应
+
+所有新接口使用统一错误格式：
+
+```json
+{
+  "status": "error",
+  "data": null,
+  "error": {
+    "code": "INVALID_ARGUMENT",
+    "message": "session_id or repo_url is required",
+    "details": {}
+  }
+}
+```
+
+常见 `code` 值：
+
+| code | 场景 |
+|------|------|
+| `INVALID_ARGUMENT` | 缺少必填参数、session 未分析 |
+| `INTERNAL` | 服务内部异常 |
+
+---
+
+## 4. 如何测试
+
+### 4.1 离线单元测试（推荐，无需 API Key / 数据库）
+
+```bash
+# 在项目根目录
+pip install pytest          # 如未安装
+python -m pytest tests/test_part_c.py -v
+```
+
+**预期输出：20 passed**
+
+测试覆盖：
+
+| 测试类 | 覆盖内容 |
+|--------|---------|
+| `TestSchemaToDict` (4) | `to_dict()` 字段完整性、`compute_level/tier` 边界 |
+| `TestRuleBasedScoring` (3) | 完整仓库高分、空仓库零分、最小仓库部分得分 |
+| `TestComputeReproScore` (5) | 正常结果、契约字段、无上下文报错、repo_url 解析、参数缺失 |
+| `TestComputePaperAlignment` (6) | 正常结果、契约字段、confidence 计算、空 paper、无上下文、top_k clamp |
+| `TestLLMFallback` (2) | LLM 不可用时评分降级、对齐降级 |
+
+### 4.2 集成测试（需要已分析的仓库 session）
+
+1. 先正常 analyze 一个仓库（如 RepoReaper 自身）：
+   - 访问 `http://localhost:8000`
+   - 输入 `https://github.com/tzzp1224/RepoReaper` 并完成分析
+
+2. 测试评分接口：
+
+```bash
+curl -X POST http://localhost:8000/api/repro/score \
+  -H "Content-Type: application/json" \
+  -d '{"repo_url": "https://github.com/tzzp1224/RepoReaper"}'
+```
+
+3. 测试对齐接口：
+
+```bash
+curl -X POST http://localhost:8000/api/paper/align \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/tzzp1224/RepoReaper",
+    "paper_text": "The system uses hybrid retrieval combining vector search and BM25 with RRF fusion. It supports multi-language AST parsing for Python, Java, and TypeScript.",
+    "top_k": 5
+  }'
+```
+
+---
+
+## 5. Mock 数据说明
+
+`tests/test_part_c.py` 内含完整的 mock 数据，可直接作为前端/联调的参考：
+
+| 常量 | 模拟内容 |
+|------|---------|
+| `MOCK_FILE_TREE` | 一个典型 ML 仓库的文件树 |
+| `MOCK_REPORT` | 分析报告文本 |
+| `MOCK_SESSION_CONTEXT` | `load_context()` 的完整返回值 |
+| `MOCK_SEARCH_RESULTS` | `search_hybrid()` 返回的代码片段列表 |
+| `LLM_RISK_RESPONSE` | LLM 对评分请求的 JSON 回复 |
+| `LLM_CLAIMS_RESPONSE` | LLM 拆 claim 的 JSON 回复 |
+| `LLM_JUDGE_ALIGNED/PARTIAL/MISSING` | LLM 对齐判定的三种回复 |
+
+前端可直接使用上述 mock 的 response 结构进行开发。
+
+---
+
+## 6. 与其他成员的对接点
+
+| 对接方 | 内容 |
+|--------|------|
+| **成员 A** | 路由已预注册；A 可将 `_unified_success/_unified_error` 提取到公共模块 |
+| **成员 B** | `community_stability` 维度可接入 B 的 `IssueCommitInsight` 增强打分 |
+| **成员 D** | 前端按 §2 的 response 结构渲染评分卡和对齐结果 |
+
+---
+
+## 7. 测试结果
+
+```
+tests/test_part_c.py::TestSchemaToDict::test_repro_score_result_to_dict_has_all_keys    PASSED
+tests/test_part_c.py::TestSchemaToDict::test_paper_align_result_to_dict_has_all_keys    PASSED
+tests/test_part_c.py::TestSchemaToDict::test_compute_level_boundaries                   PASSED
+tests/test_part_c.py::TestSchemaToDict::test_compute_tier_boundaries                    PASSED
+tests/test_part_c.py::TestRuleBasedScoring::test_full_repo_scores_high                  PASSED
+tests/test_part_c.py::TestRuleBasedScoring::test_empty_tree_scores_zero                 PASSED
+tests/test_part_c.py::TestRuleBasedScoring::test_minimal_repo                           PASSED
+tests/test_part_c.py::TestComputeReproScore::test_returns_valid_result                  PASSED
+tests/test_part_c.py::TestComputeReproScore::test_to_dict_matches_contract              PASSED
+tests/test_part_c.py::TestComputeReproScore::test_no_context_raises                     PASSED
+tests/test_part_c.py::TestComputeReproScore::test_repo_url_resolves_session             PASSED
+tests/test_part_c.py::TestComputeReproScore::test_missing_both_raises                   PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_returns_valid_result              PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_to_dict_matches_contract          PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_confidence_calculation            PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_empty_paper_text_raises           PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_no_context_raises                 PASSED
+tests/test_part_c.py::TestComputePaperAlignment::test_top_k_clamp                       PASSED
+tests/test_part_c.py::TestLLMFallback::test_score_without_llm                           PASSED
+tests/test_part_c.py::TestLLMFallback::test_align_without_llm                           PASSED
+
+======================== 20 passed in 0.25s =========================
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+测试全局 conftest
+
+在任何 app.* 模块被 import 之前，先设置环境变量并 stub 掉重型第三方依赖，
+使测试不需要 qdrant_client、openai、sse_starlette 等即可离线运行。
+"""
+
+import os
+import sys
+import types
+
+# ---- 1. 环境变量 ----
+os.environ.setdefault("DEEPSEEK_API_KEY", "test-mock-key-not-real")
+os.environ.setdefault("LLM_PROVIDER", "deepseek")
+
+
+def _ensure_stub(name, attrs=None):
+    """确保 sys.modules 里有一个 stub module，并设置指定属性。"""
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod = sys.modules[name]
+    for k, v in (attrs or {}).items():
+        setattr(mod, k, v)
+    return mod
+
+
+# ---- 2. qdrant_client ----
+_dummy_cls = type("_Dummy", (), {"__init__": lambda self, *a, **kw: None})
+
+
+class _FakeDistance:
+    COSINE = "Cosine"
+    EUCLID = "Euclid"
+    DOT = "Dot"
+
+
+class _FakePayloadSchemaType:
+    KEYWORD = "keyword"
+    INTEGER = "integer"
+    FLOAT = "float"
+    TEXT = "text"
+
+
+_ensure_stub("qdrant_client", {
+    "AsyncQdrantClient": _dummy_cls,
+    "models": _ensure_stub("qdrant_client.models", {
+        "Distance": _FakeDistance,
+        "VectorParams": _dummy_cls,
+        "PointStruct": _dummy_cls,
+        "Filter": _dummy_cls,
+        "FieldCondition": _dummy_cls,
+        "MatchValue": _dummy_cls,
+        "PayloadSchemaType": _FakePayloadSchemaType,
+    }),
+})
+
+# ---- 3. openai (被 app.utils.embedding import) ----
+_ensure_stub("openai", {
+    "AsyncOpenAI": _dummy_cls,
+    "OpenAI": _dummy_cls,
+})
+
+# ---- 4. sse_starlette ----
+_ensure_stub("sse_starlette")
+_ensure_stub("sse_starlette.sse", {
+    "EventSourceResponse": _dummy_cls,
+})

--- a/tests/part_c/conftest.py
+++ b/tests/part_c/conftest.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-测试全局 conftest
+Part C 专属 conftest —— 仅在 tests/part_c/ 作用域内生效。
 
 在任何 app.* 模块被 import 之前，先设置环境变量并 stub 掉重型第三方依赖，
-使测试不需要 qdrant_client、openai、sse_starlette 等即可离线运行。
+使 Part C 测试不需要 qdrant_client、openai、sse_starlette 等即可离线运行。
+不影响仓库中其他测试。
 """
 
 import os

--- a/tests/part_c/test_part_c.py
+++ b/tests/part_c/test_part_c.py
@@ -6,7 +6,7 @@ Part C 单元测试 —— 可复现评分 & 论文-代码对齐
 不需要网络、数据库或 API Key 即可运行。
 
 运行方式:
-    pytest tests/test_part_c.py -v
+    pytest tests/part_c/test_part_c.py -v
 """
 
 from __future__ import annotations
@@ -161,7 +161,7 @@ LLM_JUDGE_MISSING = json.dumps({
 
 # 按调用顺序排列：score 用 1 次 LLM，align 用 1(拆claim) + 3(judge) 次
 async def _empty_issue_commit_insight(*args, **kwargs):
-    """避免单测打真实 GitHub API。"""
+    """避免单测打真实 GitHub API。返回 degraded=False 的空结构。"""
     return {
         "issue_risks": [],
         "recent_feats": [],
@@ -171,6 +171,7 @@ async def _empty_issue_commit_insight(*args, **kwargs):
             "risk_issue_count": 0,
             "recent_feat_count": 0,
         },
+        "degraded": False,
     }
 
 
@@ -474,6 +475,7 @@ class TestComputeReproScore:
                     "risk_issue_count": 0,
                     "recent_feat_count": 0,
                 },
+                "degraded": False,
             }
 
         monkeypatch.setattr(mod, "fetch_issue_commit_insight", capture_fetch)

--- a/tests/test_part_c.py
+++ b/tests/test_part_c.py
@@ -1,0 +1,649 @@
+# -*- coding: utf-8 -*-
+"""
+Part C 单元测试 —— 可复现评分 & 论文-代码对齐
+
+所有外部依赖 (store_manager、LLM client、settings) 全部 mock，
+不需要网络、数据库或 API Key 即可运行。
+
+运行方式:
+    pytest tests/test_part_c.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import asyncio
+import pytest
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+# ============================================================
+# Mock 数据 —— 模拟一个 "已分析" 的仓库 session
+# ============================================================
+
+MOCK_FILE_TREE = """\
+README.md
+LICENSE
+requirements.txt
+setup.py
+Dockerfile
+.env.example
+.github/workflows/ci.yml
+.github/ISSUE_TEMPLATE/bug_report.md
+CONTRIBUTING.md
+CHANGELOG.md
+src/
+  main.py
+  model.py
+  train.py
+  data_loader.py
+tests/
+  test_model.py
+  test_train.py
+docs/
+  guide.md
+examples/
+  demo.py
+"""
+
+MOCK_REPORT = (
+    "This repository implements a two-stage retrieval pipeline for code analysis. "
+    "It includes a training script, a model definition, and evaluation utilities. "
+    "Dependencies are pinned in requirements.txt. Docker support is provided. "
+    "Some users report CUDA version conflicts in open issues."
+)
+
+MOCK_SESSION_CONTEXT = {
+    "repo_url": "https://github.com/mock-owner/mock-repo",
+    "global_context": {
+        "file_tree": MOCK_FILE_TREE,
+        "summary": "A ML research repo with training, inference and evaluation.",
+    },
+    "reports": {
+        "en": MOCK_REPORT,
+    },
+}
+
+MOCK_SEARCH_RESULTS: List[Dict[str, Any]] = [
+    {
+        "id": "src/model.py_0",
+        "content": (
+            "class TwoStageRetriever:\n"
+            "    def __init__(self, encoder, reranker):\n"
+            "        self.encoder = encoder\n"
+            "        self.reranker = reranker\n"
+            "\n"
+            "    def search_hybrid(self, query, top_k=10):\n"
+            "        candidates = self.encoder.encode(query)\n"
+            "        return self.reranker.rerank(candidates, top_k)\n"
+        ),
+        "file": "src/model.py",
+        "metadata": {"file": "src/model.py", "type": "class", "name": "TwoStageRetriever"},
+        "score": 0.92,
+    },
+    {
+        "id": "src/train.py_0",
+        "content": (
+            "def train_epoch(model, dataloader, optimizer):\n"
+            "    model.train()\n"
+            "    for batch in dataloader:\n"
+            "        loss = model(batch)\n"
+            "        loss.backward()\n"
+            "        optimizer.step()\n"
+        ),
+        "file": "src/train.py",
+        "metadata": {"file": "src/train.py", "type": "function", "name": "train_epoch"},
+        "score": 0.85,
+    },
+    {
+        "id": "src/data_loader.py_0",
+        "content": (
+            "class DataPipeline:\n"
+            "    def preprocess(self, raw):\n"
+            "        return tokenize(clean(raw))\n"
+        ),
+        "file": "src/data_loader.py",
+        "metadata": {"file": "src/data_loader.py", "type": "class", "name": "DataPipeline"},
+        "score": 0.78,
+    },
+]
+
+# ---- LLM 预设回复 ----
+
+LLM_RISK_RESPONSE = json.dumps({
+    "risks": [
+        {
+            "title": "CUDA version conflict",
+            "reason": "Multiple open issues about CUDA 12 incompatibility",
+            "evidence_refs": ["issue#42", "issue#58"],
+        },
+        {
+            "title": "Missing pinned CUDA in Dockerfile",
+            "reason": "Dockerfile does not pin CUDA toolkit version",
+            "evidence_refs": ["Dockerfile"],
+        },
+    ],
+    "summary": "Repository is partially reproducible; environment setup has moderate risk due to CUDA conflicts.",
+})
+
+LLM_CLAIMS_RESPONSE = json.dumps({
+    "claims": [
+        "The system uses a two-stage retrieval pipeline.",
+        "Training uses a standard epoch-based loop with backpropagation.",
+        "The model performs ablation study on encoder variants.",
+    ],
+})
+
+LLM_JUDGE_ALIGNED = json.dumps({
+    "status": "aligned",
+    "matched_files": ["src/model.py"],
+    "matched_symbols": ["TwoStageRetriever", "search_hybrid"],
+    "evidence_excerpt": "class TwoStageRetriever … def search_hybrid",
+    "reason": "Code clearly implements two-stage retrieval.",
+})
+
+LLM_JUDGE_PARTIAL = json.dumps({
+    "status": "partial",
+    "matched_files": ["src/train.py"],
+    "matched_symbols": ["train_epoch"],
+    "evidence_excerpt": "def train_epoch(model, dataloader, optimizer)",
+    "reason": "Standard training loop present but no explicit backprop details.",
+})
+
+LLM_JUDGE_MISSING = json.dumps({
+    "status": "missing",
+    "matched_files": [],
+    "matched_symbols": [],
+    "evidence_excerpt": "",
+    "reason": "No ablation study implementation found in the repository.",
+})
+
+# 按调用顺序排列：score 用 1 次 LLM，align 用 1(拆claim) + 3(judge) 次
+async def _empty_issue_commit_insight(*args, **kwargs):
+    """避免单测打真实 GitHub API。"""
+    return {
+        "issue_risks": [],
+        "recent_feats": [],
+        "stats": {
+            "issues_total_scanned": 0,
+            "commits_total_scanned": 0,
+            "risk_issue_count": 0,
+            "recent_feat_count": 0,
+        },
+    }
+
+
+LLM_RESPONSES_QUEUE = [
+    LLM_RISK_RESPONSE,     # repro score → risks
+    LLM_CLAIMS_RESPONSE,   # paper align → extract claims
+    LLM_JUDGE_ALIGNED,     # claim 1 judge
+    LLM_JUDGE_PARTIAL,     # claim 2 judge
+    LLM_JUDGE_MISSING,     # claim 3 judge
+]
+
+
+# ============================================================
+# Mock 对象
+# ============================================================
+
+@dataclass
+class _FakeMessage:
+    content: str
+
+@dataclass
+class _FakeChoice:
+    message: _FakeMessage
+
+@dataclass
+class _FakeCompletion:
+    choices: List[_FakeChoice]
+
+
+class _FakeLLMCompletions:
+    """模拟 client.chat.completions，按顺序返回预设回复。"""
+
+    def __init__(self, responses: List[str]):
+        self._responses = list(responses)
+        self._idx = 0
+
+    async def create(self, **kwargs):
+        if self._idx >= len(self._responses):
+            raise RuntimeError("LLM mock: no more responses in queue")
+        text = self._responses[self._idx]
+        self._idx += 1
+        return _FakeCompletion(choices=[_FakeChoice(message=_FakeMessage(content=text))])
+
+
+class _FakeLLMChat:
+    def __init__(self, completions: _FakeLLMCompletions):
+        self.completions = completions
+
+
+class FakeLLMClient:
+    """完整的假 LLM 客户端，兼容 client.chat.completions.create(...)"""
+
+    def __init__(self, responses: List[str]):
+        self.chat = _FakeLLMChat(_FakeLLMCompletions(responses))
+
+
+class FakeVectorStore:
+    """模拟 VectorStore，返回固定的 context 和搜索结果。"""
+
+    def __init__(self, context: Optional[Dict], search_results: List[Dict]):
+        self._context = context
+        self._search_results = search_results
+
+    def load_context(self):
+        return self._context
+
+    def get_report(self, language: str) -> Optional[str]:
+        if not self._context:
+            return None
+        reports = self._context.get("reports", {})
+        return reports.get(language)
+
+    async def search_hybrid(self, query: str, top_k: int = 5) -> List[Dict]:
+        return self._search_results[:top_k]
+
+
+class FakeStoreManager:
+    def __init__(self, store: FakeVectorStore):
+        self._store = store
+
+    def get_store(self, session_id: str) -> FakeVectorStore:
+        return self._store
+
+
+# ============================================================
+# 测试：Schema to_dict
+# ============================================================
+
+class TestSchemaToDict:
+    def test_repro_score_result_to_dict_has_all_keys(self):
+        from app.schemas.repro import ReproScoreResult, DimensionScores, ScoreRisk
+
+        dim = DimensionScores(0.8, 0.68, 0.7, 0.66)
+        result = ReproScoreResult(
+            overall_score=71,
+            overall_score_raw=0.71,
+            level="medium",
+            quality_tier="silver",
+            dimension_scores=dim,
+            dimension_scores_raw=dim,
+            risks=[ScoreRisk("risk1", "reason1", ["ref1"])],
+            evidence_refs=["README.md"],
+            summary="test summary",
+        )
+        d = result.to_dict()
+        assert d["overall_score"] == 71
+        assert d["level"] == "medium"
+        assert d["quality_tier"] == "silver"
+        assert "code_structure" in d["dimension_scores"]
+        assert "code_structure" in d["dimension_scores_raw"]
+        assert len(d["risks"]) == 1
+        assert d["risks"][0]["title"] == "risk1"
+
+    def test_paper_align_result_to_dict_has_all_keys(self):
+        from app.schemas.repro import PaperAlignResult, AlignmentItem, MissingClaim
+
+        result = PaperAlignResult(
+            alignment_items=[
+                AlignmentItem("claim1", "aligned", ["f.py"], ["func"], "excerpt"),
+            ],
+            missing_claims=[
+                MissingClaim("claim2", "not found"),
+            ],
+            confidence=0.75,
+        )
+        d = result.to_dict()
+        assert len(d["alignment_items"]) == 1
+        assert d["alignment_items"][0]["status"] == "aligned"
+        assert len(d["missing_claims"]) == 1
+        assert d["confidence"] == 0.75
+
+    def test_compute_level_boundaries(self):
+        from app.schemas.repro import ReproScoreResult
+        assert ReproScoreResult.compute_level(0.80) == "high"
+        assert ReproScoreResult.compute_level(0.79) == "medium"
+        assert ReproScoreResult.compute_level(0.60) == "medium"
+        assert ReproScoreResult.compute_level(0.59) == "low"
+
+    def test_compute_tier_boundaries(self):
+        from app.schemas.repro import ReproScoreResult
+        assert ReproScoreResult.compute_tier(0.90) == "gold"
+        assert ReproScoreResult.compute_tier(0.89) == "silver"
+        assert ReproScoreResult.compute_tier(0.70) == "silver"
+        assert ReproScoreResult.compute_tier(0.69) == "bronze"
+        assert ReproScoreResult.compute_tier(0.50) == "bronze"
+        assert ReproScoreResult.compute_tier(0.49) == "rejected"
+
+
+# ============================================================
+# 测试：规则层打分（纯函数，无需 mock）
+# ============================================================
+
+class TestRuleBasedScoring:
+    def test_full_repo_scores_high(self):
+        from app.services.repro_score_service import _rule_based_scores, _aggregate
+
+        dim = _rule_based_scores(MOCK_FILE_TREE)
+        assert dim.code_structure > 0.5, f"code_structure={dim.code_structure}"
+        assert dim.docs_quality > 0.5, f"docs_quality={dim.docs_quality}"
+        assert dim.env_readiness > 0.5, f"env_readiness={dim.env_readiness}"
+
+        overall = _aggregate(dim)
+        assert overall >= 0.5, f"overall={overall}"
+
+    def test_empty_tree_scores_zero(self):
+        from app.services.repro_score_service import _rule_based_scores, _aggregate
+
+        dim = _rule_based_scores("")
+        assert dim.code_structure == 0.0
+        assert dim.docs_quality == 0.0
+        assert dim.env_readiness == 0.0
+        assert dim.community_stability == 0.0
+        assert _aggregate(dim) == 0.0
+
+    def test_minimal_repo(self):
+        from app.services.repro_score_service import _rule_based_scores
+
+        tree = "README.md\nmain.py\n"
+        dim = _rule_based_scores(tree)
+        assert dim.docs_quality > 0, "README should contribute to docs_quality"
+        assert dim.code_structure > 0, "main.py should contribute to code_structure"
+        assert dim.env_readiness == 0, "no deps/docker in minimal repo"
+
+    def test_insight_penalty_lowers_env_and_community(self):
+        from app.services.repro_score_service import _adjust_scores_for_insight, DimensionScores
+
+        base = DimensionScores(0.8, 0.8, 0.8, 0.8)
+        insight = {
+            "issue_risks": [
+                {"id": 1, "severity": "high", "risk_type": "repro_env", "title": "cuda"},
+            ]
+            * 4,
+            "stats": {"risk_issue_count": 4, "issues_total_scanned": 8},
+        }
+        adj = _adjust_scores_for_insight(base, insight)
+        assert adj.community_stability < base.community_stability
+        assert adj.env_readiness < base.env_readiness
+        assert adj.code_structure == base.code_structure
+
+
+# ============================================================
+# 测试：compute_repro_score（mock store + LLM）
+# ============================================================
+
+class TestComputeReproScore:
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        import app.services.repro_score_service as mod
+
+        fake_store = FakeVectorStore(MOCK_SESSION_CONTEXT, [])
+        fake_mgr = FakeStoreManager(fake_store)
+        monkeypatch.setattr(mod, "store_manager", fake_mgr)
+
+        fake_llm = FakeLLMClient([LLM_RISK_RESPONSE])
+        monkeypatch.setattr(mod, "get_client", lambda: fake_llm)
+
+        class FakeSettings:
+            default_model_name = "mock-model"
+        monkeypatch.setattr(mod, "settings", FakeSettings())
+        monkeypatch.setattr(mod, "fetch_issue_commit_insight", _empty_issue_commit_insight)
+
+    def test_returns_valid_result(self):
+        from app.services.repro_score_service import compute_repro_score
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_repro_score(session_id="test_session")
+        )
+
+        assert 0 <= result.overall_score <= 100
+        assert 0 <= result.overall_score_raw <= 1
+        assert result.level in ("high", "medium", "low")
+        assert result.quality_tier in ("gold", "silver", "bronze", "rejected")
+        assert len(result.risks) == 2
+        assert result.risks[0].title == "CUDA version conflict"
+        assert "README" in result.evidence_refs or "README.md" in result.evidence_refs
+        assert result.summary != ""
+
+    def test_to_dict_matches_contract(self):
+        from app.services.repro_score_service import compute_repro_score
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_repro_score(session_id="test_session")
+        )
+        d = result.to_dict()
+
+        contract_keys = {
+            "overall_score", "overall_score_raw", "level", "quality_tier",
+            "dimension_scores", "dimension_scores_raw",
+            "risks", "evidence_refs", "summary",
+        }
+        assert set(d.keys()) == contract_keys
+
+        dim_keys = {"code_structure", "docs_quality", "env_readiness", "community_stability"}
+        assert set(d["dimension_scores"].keys()) == dim_keys
+        assert set(d["dimension_scores_raw"].keys()) == dim_keys
+
+    def test_no_context_raises(self, monkeypatch):
+        import app.services.repro_score_service as mod
+
+        empty_store = FakeVectorStore(None, [])
+        monkeypatch.setattr(mod, "store_manager", FakeStoreManager(empty_store))
+        monkeypatch.setattr(mod, "fetch_issue_commit_insight", _empty_issue_commit_insight)
+
+        from app.services.repro_score_service import compute_repro_score
+
+        with pytest.raises(ValueError, match="no analyzed context"):
+            asyncio.get_event_loop().run_until_complete(
+                compute_repro_score(session_id="empty")
+            )
+
+    def test_repo_url_resolves_session(self):
+        from app.services.repro_score_service import compute_repro_score
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_repro_score(repo_url="https://github.com/mock-owner/mock-repo")
+        )
+        assert result.overall_score > 0
+
+    def test_missing_both_raises(self):
+        from app.services.repro_score_service import compute_repro_score
+
+        with pytest.raises(ValueError, match="至少提供一个"):
+            asyncio.get_event_loop().run_until_complete(
+                compute_repro_score()
+            )
+
+    def test_insight_since_days_and_limit_forwarded(self, monkeypatch):
+        import app.services.repro_score_service as mod
+
+        captured: dict = {}
+
+        async def capture_fetch(rurl, since_days=90, limit=100):
+            captured["since_days"] = since_days
+            captured["limit"] = limit
+            return {
+                "issue_risks": [],
+                "recent_feats": [],
+                "stats": {
+                    "issues_total_scanned": 0,
+                    "commits_total_scanned": 0,
+                    "risk_issue_count": 0,
+                    "recent_feat_count": 0,
+                },
+            }
+
+        monkeypatch.setattr(mod, "fetch_issue_commit_insight", capture_fetch)
+
+        from app.services.repro_score_service import compute_repro_score
+
+        asyncio.get_event_loop().run_until_complete(
+            compute_repro_score(
+                session_id="test_session",
+                insight_since_days=30,
+                insight_limit=50,
+            )
+        )
+        assert captured["since_days"] == 30
+        assert captured["limit"] == 50
+
+
+# ============================================================
+# 测试：compute_paper_alignment（mock store + LLM）
+# ============================================================
+
+class TestComputePaperAlignment:
+    @pytest.fixture(autouse=True)
+    def _patch(self, monkeypatch):
+        import app.services.paper_align_service as mod
+
+        fake_store = FakeVectorStore(MOCK_SESSION_CONTEXT, MOCK_SEARCH_RESULTS)
+        fake_mgr = FakeStoreManager(fake_store)
+        monkeypatch.setattr(mod, "store_manager", fake_mgr)
+
+        fake_llm = FakeLLMClient([
+            LLM_CLAIMS_RESPONSE,
+            LLM_JUDGE_ALIGNED,
+            LLM_JUDGE_PARTIAL,
+            LLM_JUDGE_MISSING,
+        ])
+        monkeypatch.setattr(mod, "get_client", lambda: fake_llm)
+
+        class FakeSettings:
+            default_model_name = "mock-model"
+        monkeypatch.setattr(mod, "settings", FakeSettings())
+
+    def test_returns_valid_result(self):
+        from app.services.paper_align_service import compute_paper_alignment
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_paper_alignment(
+                paper_text="We propose a two-stage retrieval pipeline with ablation.",
+                session_id="test_session",
+            )
+        )
+
+        assert len(result.alignment_items) == 2
+        assert result.alignment_items[0].status == "aligned"
+        assert result.alignment_items[1].status == "partial"
+        assert len(result.missing_claims) == 1
+        assert 0 < result.confidence < 1
+
+    def test_to_dict_matches_contract(self):
+        from app.services.paper_align_service import compute_paper_alignment
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_paper_alignment(
+                paper_text="Some method claims",
+                session_id="test_session",
+            )
+        )
+        d = result.to_dict()
+
+        assert "alignment_items" in d
+        assert "missing_claims" in d
+        assert "confidence" in d
+
+        if d["alignment_items"]:
+            item = d["alignment_items"][0]
+            assert set(item.keys()) == {
+                "claim", "status", "matched_files", "matched_symbols", "evidence_excerpt",
+            }
+
+        if d["missing_claims"]:
+            mc = d["missing_claims"][0]
+            assert set(mc.keys()) == {"claim", "reason"}
+
+    def test_confidence_calculation(self):
+        from app.services.paper_align_service import compute_paper_alignment
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_paper_alignment(
+                paper_text="method claims",
+                session_id="test_session",
+            )
+        )
+        # 3 claims: aligned(1.0) + partial(0.5) + missing(0) = 1.5 / 3 = 0.5
+        assert result.confidence == 0.5
+
+    def test_empty_paper_text_raises(self):
+        from app.services.paper_align_service import compute_paper_alignment
+
+        with pytest.raises(ValueError, match="paper_text is required"):
+            asyncio.get_event_loop().run_until_complete(
+                compute_paper_alignment(paper_text="", session_id="test")
+            )
+
+    def test_no_context_raises(self, monkeypatch):
+        import app.services.paper_align_service as mod
+
+        empty_store = FakeVectorStore(None, [])
+        monkeypatch.setattr(mod, "store_manager", FakeStoreManager(empty_store))
+
+        from app.services.paper_align_service import compute_paper_alignment
+
+        with pytest.raises(ValueError, match="no analyzed context"):
+            asyncio.get_event_loop().run_until_complete(
+                compute_paper_alignment(paper_text="claims", session_id="empty")
+            )
+
+    def test_top_k_clamp(self):
+        from app.services.paper_align_service import compute_paper_alignment
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_paper_alignment(
+                paper_text="claims",
+                session_id="test_session",
+                top_k=999,
+            )
+        )
+        assert result is not None
+
+
+# ============================================================
+# 测试：LLM 不可用时的降级
+# ============================================================
+
+class TestLLMFallback:
+    def test_score_without_llm(self, monkeypatch):
+        import app.services.repro_score_service as mod
+
+        fake_store = FakeVectorStore(MOCK_SESSION_CONTEXT, [])
+        monkeypatch.setattr(mod, "store_manager", FakeStoreManager(fake_store))
+        monkeypatch.setattr(mod, "get_client", lambda: None)
+        monkeypatch.setattr(mod, "fetch_issue_commit_insight", _empty_issue_commit_insight)
+
+        class FakeSettings:
+            default_model_name = "mock"
+        monkeypatch.setattr(mod, "settings", FakeSettings())
+
+        from app.services.repro_score_service import compute_repro_score
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_repro_score(session_id="test")
+        )
+        assert result.overall_score > 0
+        assert result.risks == []
+        assert "unavailable" in result.summary.lower()
+
+    def test_align_without_llm(self, monkeypatch):
+        import app.services.paper_align_service as mod
+
+        fake_store = FakeVectorStore(MOCK_SESSION_CONTEXT, MOCK_SEARCH_RESULTS)
+        monkeypatch.setattr(mod, "store_manager", FakeStoreManager(fake_store))
+        monkeypatch.setattr(mod, "get_client", lambda: None)
+
+        class FakeSettings:
+            default_model_name = "mock"
+        monkeypatch.setattr(mod, "settings", FakeSettings())
+
+        from app.services.paper_align_service import compute_paper_alignment
+
+        result = asyncio.get_event_loop().run_until_complete(
+            compute_paper_alignment(paper_text="claims", session_id="test")
+        )
+        assert result.confidence == 0.0
+        assert len(result.missing_claims) > 0


### PR DESCRIPTION
## 摘要
实现开发契约 V1.1 **成员 C**：新增 `POST /api/repro/score`、`POST /api/paper/align`、`POST /api/repo/insight/issues-commits`，评分融合 GitHub Issues/Commits 洞察；扩展 `GitHubClient` 分页拉取 issues/commits。

## 主要变更
- **`/api/repro/score`**：规则四维度 + LLM risks/summary；insight 校正 community/env；可选 `since_days` / `limit`
- **`/api/paper/align`**：拆 claim → hybrid 检索 → 对齐判定
- **`/api/repo/insight/issues-commits`**：§3.1 结构化返回
- **`app/schemas/repro.py`**：契约数据模型
- **文档**：`docs/development_contract_v1.md` §3.2 补充；`docs/part_c_interface.md`

## Review 修改（841ae85）
1. **JSON body 解析兜底**：3 个新路由统一通过 `_parse_json_body()` 校验请求体；坏 JSON / 非 object body 返回 `INVALID_ARGUMENT` 契约错误，不再透传框架默认异常。
2. **GitHub 失败语义明确**：`issue_commit_insight_service` 区分 `UPSTREAM_UNAVAILABLE`（GitHub API 错误 → 502）和 `degraded=true`（降级成功），不再"失败=success 空数据"；`repro_score_service` 在 insight 降级时跳过惩罚调整。
3. **status 白名单**：`paper_align_service._judge_claim` 仅允许 `aligned|partial|missing`，未知值一律按 `missing` 处理，避免抬高 confidence。
4. **测试 stub 作用域收敛**：全局 `tests/conftest.py` 迁移至 `tests/part_c/conftest.py`，不再污染其他测试套件。

## 验证
```bash
# Part C 22 条用例
python -m pytest tests/part_c/test_part_c.py -v

# 全仓 52 条用例（含其他成员 30 条）
python -m pytest tests/ -v
```
全部 52 tests passed。

## Test plan
- [x] Part C 22 条离线单测通过
- [x] 其他成员 30 条测试不受影响
- [x] JSON body 解析兜底（坏 JSON / 非 object）
- [x] insight 失败语义区分（UPSTREAM_UNAVAILABLE vs degraded）
- [x] status 白名单校验（未知值→missing）
- [x] conftest stub 不污染全仓